### PR TITLE
Fix Eigen matrix broadcasting issue in forward pass for MNIST data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,71 @@
 # NeuroNet
+
+NeuroNet is a neural network implementation in C++ leveraging the Eigen library for matrix operations. This project is structured to support custom neural network layers and optimized backpropagation, with an example classifier for the MNIST dataset.
+
+## Features
+
+- **Layered Architecture**: Utilizes a DenseLayer structure, supporting forward and backward propagation.
+- **Optimization and Loss Functions**:
+    - **Optimizer**: Stochastic Gradient Descent (SGD) with weight updates. 
+    - **Loss Function**: Cross-Entropy loss, ideal for classification tasks.
+- **Debug Logging**: Debug statements log matrix dimensions and provide insights into forward and backward passes for troubleshooting.
+- **Eigen Matrix Broadcasting**: Customized solution for bias broacasting issues with Eigen, using manual replication for compatibility.
+
+## Installation
+
+### Prerequisites
+
+- **Eigen Library**: Eigen is a C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms. Ensure Eigen is available in the third_party directory or download Eigen from the [official website](http://eigen.tuxfamily.org/index.php?title=Main_Page) or install via your package manager.
+- **CMake and Make**: Required to build the project. 
+
+### Building NeuroNet
+
+1. Clone the repository:
+
+```bash
+git clone https://github.com/chizy7/NeuroNet.git
+cd NeuroNet
+```
+
+2. Build with CMake:
+
+```bash
+mkdir build && cd build
+cmake ..
+make
+```
+
+3. Run the executable:
+
+```bash
+./NeuroNet
+```
+
+## Dataset
+
+To run the example MNIST classifier, download the MNIST dataset in CSV format from [this Kaggle dataset](https://www.kaggle.com/datasets/oddrationale/mnist-in-csv?select=mnist_test.csv).
+
+1. Download both mnist_train.csv and mnist_test.csv.
+2. Place them in the data/ directory of the project.
+
+## Usage
+
+1. **Train the Model**: NeuroNet loads MNIST data, trains for specified epochs, and prints accuracy.
+2. **Debugging Mode**: Enable debug in `logger.h` to get detailed layer-wise output of matrix sizes during the forward and backward passes.
+
+## Code Structure
+
+- **src/core/Layer.cpp**: Contains layer definitions and forward/backward functions.
+- **src/core/NeuralNet.cpp**: Core neural network functionality, including training and evaluation.
+- **include/:** Headers for neural network components and utilities. 
+- **data/:** MNIST CSV files.
+
+## Known Issues and Improvements
+
+- **Additional Layers**: Currently, only DenseLayer is implemented. Other layer types (e.g., convolutional) could be added. 
+- **Evaluation Metrics**: Extend beyond accuracy for multi-class tasks. 
+- **Memory Optimization**: Explore more efficient memory handling for large datasets.
+
+## License
+
+This project is licenced under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/include/DataLoader.h
+++ b/include/DataLoader.h
@@ -4,5 +4,5 @@
 
 class DataLoader {
 public:
-    static Eigen::MatrixXd load_csv(const std::string& file_path);
+    static void load_mnist_csv(const std::string& file_path, Eigen::MatrixXd& data, Eigen::VectorXi& labels);
 };

--- a/include/Logger.h
+++ b/include/Logger.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <string>
 
+extern bool debug; // Debug flag for global access
+
 class Logger {
 public:
     static void info(const std::string& message);

--- a/include/Loss.h
+++ b/include/Loss.h
@@ -7,7 +7,7 @@ public:
     virtual Eigen::MatrixXd gradient(const Eigen::MatrixXd& Y_pred, const Eigen::MatrixXd& Y_true) = 0;
 };
 
-class MSE : public Loss {
+class CrossEntropyLoss : public Loss {
 public:
     double calculate(const Eigen::MatrixXd& Y_pred, const Eigen::MatrixXd& Y_true) override;
     Eigen::MatrixXd gradient(const Eigen::MatrixXd& Y_pred, const Eigen::MatrixXd& Y_true) override;

--- a/include/NeuralNetwork.h
+++ b/include/NeuralNetwork.h
@@ -13,7 +13,12 @@ public:
     Eigen::MatrixXd forward(const Eigen::MatrixXd& input);
     void backward(const Eigen::MatrixXd& output, const Eigen::MatrixXd& labels);
     void compile(Optimizer* optimizer, Loss* loss_fn);
-    void train(const Eigen::MatrixXd& X, const Eigen::MatrixXd& Y, int epochs);
+    
+    // Training with batch size
+    void train(const Eigen::MatrixXd& X, const Eigen::VectorXi& Y, int epochs, int batch_size);
+    
+    // Evaluate the model accuracy on test data
+    double evaluate(const Eigen::MatrixXd& X, const Eigen::VectorXi& Y);
 
 private:
     std::vector<Layer*> layers;

--- a/src/core/Layer.cpp
+++ b/src/core/Layer.cpp
@@ -1,4 +1,5 @@
 #include "Layer.h"
+#include "Logger.h"
 #include <iostream>
 
 DenseLayer::DenseLayer(int input_size, int output_size) {
@@ -7,15 +8,56 @@ DenseLayer::DenseLayer(int input_size, int output_size) {
 }
 
 Eigen::MatrixXd DenseLayer::forward(const Eigen::MatrixXd& input) {
+    if (debug) {
+        std::cout << "[DenseLayer Forward] Input size: " << input.rows() << "x" << input.cols() << std::endl;
+        std::cout << "[DenseLayer Forward] Weights size: " << weights.rows() << "x" << weights.cols() << std::endl;
+        std::cout << "[DenseLayer Forward] Bias size: " << bias.rows() << "x" << bias.cols() << std::endl;
+    }
+    
     input_cache = input;
-    // return (weights * input).colwise() + bias;
-    return (weights * input).colwise() + bias.col(0);
+    Eigen::MatrixXd output = input * weights.transpose();
+
+    // Create a matrix of the same size as output, where each row is a copy of the bias vector
+    Eigen::MatrixXd bias_expanded = bias.transpose().replicate(output.rows(), 1);
+
+    if (debug) {
+        std::cout << "[DenseLayer Forward] Output before bias addition size: " << output.rows() << "x" << output.cols() << std::endl;
+        std::cout << "[DenseLayer Forward] Expanded bias size: " << bias_expanded.rows() << "x" << bias_expanded.cols() << std::endl;
+    }
+    
+    output += bias_expanded;
+
+    if (debug) {
+        std::cout << "[DenseLayer Forward] Output after bias addition size: " << output.rows() << "x" << output.cols() << std::endl;
+    }
+    
+    return output;
 }
 
 Eigen::MatrixXd DenseLayer::backward(const Eigen::MatrixXd& grad_output) {
-    grad_weights = grad_output * input_cache.transpose();
-    grad_bias = grad_output.rowwise().sum();
-    return weights.transpose() * grad_output;
+    // Verify that the dimensions of grad_output are compatible with weights
+    if (grad_output.cols() != weights.rows()) {
+        std::cerr << "Backward pass dimension mismatch: grad_output.cols() = "
+                  << grad_output.cols() << ", weights.rows() = " << weights.rows()
+                  << std::endl;
+        exit(1);
+    }
+
+    // Compute gradients
+    grad_weights = grad_output.transpose() * input_cache;
+    grad_bias = grad_output.colwise().sum().transpose();  // Ensure grad_bias is a column vector
+
+    // Compute grad_input
+    Eigen::MatrixXd grad_input = grad_output * weights;
+
+    // Log dimensions for debugging
+    if (debug) {
+        std::cout << "[DenseLayer Backward] grad_weights size: " << grad_weights.rows() << "x" << grad_weights.cols() << std::endl;
+        std::cout << "[DenseLayer Backward] grad_bias size: " << grad_bias.rows() << "x" << grad_bias.cols() << std::endl;
+        std::cout << "[DenseLayer Backward] grad_input size: " << grad_input.rows() << "x" << grad_input.cols() << std::endl;
+    }
+
+    return grad_input;
 }
 
 void DenseLayer::update_weights(double learning_rate) {

--- a/src/core/Loss.cpp
+++ b/src/core/Loss.cpp
@@ -1,10 +1,10 @@
 #include "Loss.h"
 #include <iostream>
 
-double MSE::calculate(const Eigen::MatrixXd& Y_pred, const Eigen::MatrixXd& Y_true) {
-    return (Y_pred - Y_true).array().square().mean();
+double CrossEntropyLoss::calculate(const Eigen::MatrixXd& Y_pred, const Eigen::MatrixXd& Y_true) {
+    return -(Y_true.array() * Y_pred.array().log()).sum() / Y_true.rows();
 }
 
-Eigen::MatrixXd MSE::gradient(const Eigen::MatrixXd& Y_pred, const Eigen::MatrixXd& Y_true) {
-    return 2 * (Y_pred - Y_true) / Y_true.rows();
+Eigen::MatrixXd CrossEntropyLoss::gradient(const Eigen::MatrixXd& Y_pred, const Eigen::MatrixXd& Y_true) {
+    return -Y_true.array() / Y_pred.array();
 }

--- a/src/core/NeuralNetwork.cpp
+++ b/src/core/NeuralNetwork.cpp
@@ -1,5 +1,8 @@
 #include "NeuralNetwork.h"
+#include "Logger.h"
 #include <iostream>
+#include <algorithm>
+#include <numeric>
 
 NeuralNetwork::NeuralNetwork() : optimizer(nullptr), loss_function(nullptr) {}
 
@@ -10,7 +13,13 @@ void NeuralNetwork::add_layer(Layer* layer) {
 Eigen::MatrixXd NeuralNetwork::forward(const Eigen::MatrixXd& input) {
     Eigen::MatrixXd output = input;
     for (Layer* layer : layers) {
+        if (debug) {
+            std::cout << "Input to layer: " << output.rows() << "x" << output.cols() << std::endl;
+        }
         output = layer->forward(output);
+        if (debug) {
+            std::cout << "Output of layer: " << output.rows() << "x" << output.cols() << std::endl;
+        }
     }
     return output;
 }
@@ -28,10 +37,52 @@ void NeuralNetwork::compile(Optimizer* opt, Loss* loss_fn) {
     this->loss_function = loss_fn;
 }
 
-void NeuralNetwork::train(const Eigen::MatrixXd& X, const Eigen::MatrixXd& Y, int epochs) {
-    for (int i = 0; i < epochs; ++i) {
-        Eigen::MatrixXd output = forward(X);
-        backward(output, Y);
-        std::cout << "Epoch " << i+1 << " Loss: " << loss_function->calculate(output, Y) << std::endl;
+void NeuralNetwork::train(const Eigen::MatrixXd& X, const Eigen::VectorXi& Y, int epochs, int batch_size) {
+    int num_samples = X.rows();
+
+    for (int epoch = 0; epoch < epochs; ++epoch) {
+        double total_loss = 0.0;
+
+        for (int i = 0; i < num_samples; i += batch_size) {
+            int end = std::min(i + batch_size, num_samples);
+            Eigen::MatrixXd X_batch = X.middleRows(i, end - i);
+            Eigen::MatrixXd Y_batch = Eigen::MatrixXd::Zero(end - i, 10);
+
+            // Convert labels to one-hot encoding for the batch
+            for (int j = 0; j < end - i; ++j) {
+                Y_batch(j, Y(i + j)) = 1;
+            }
+
+            // Forward pass and compute loss
+            Eigen::MatrixXd output = forward(X_batch);
+            total_loss += loss_function->calculate(output, Y_batch);
+
+            // Backward pass and weights update
+            backward(output, Y_batch);
+        }
+
+        // Print average loss for the epoch
+        if (debug) {
+            std::cout << "Epoch " << epoch + 1 << " completed. Average Loss: " << total_loss / (num_samples / batch_size) << std::endl;
+        }
     }
+}
+
+double NeuralNetwork::evaluate(const Eigen::MatrixXd& X, const Eigen::VectorXi& Y) {
+    int num_samples = X.rows();
+    int correct = 0;
+
+    Eigen::MatrixXd output = forward(X);
+
+    for (int i = 0; i < num_samples; ++i) {
+        int predicted_class;
+        output.row(i).maxCoeff(&predicted_class);  // Get the index of the max element in the row
+        if (predicted_class == Y(i)) {
+            correct++;
+        }
+    }
+
+    double accuracy = (static_cast<double>(correct) / num_samples) * 100.0;
+    std::cout << "Accuracy: " << accuracy << "%" << std::endl;
+    return accuracy;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,28 +1,41 @@
 #include <iostream>
 #include "NeuralNetwork.h"
+#include "DataLoader.h"
 #include "Layer.h"
 #include "Optimizer.h"
 #include "Loss.h"
 #include "Logger.h"
-#include "DataLoader.h"
+#include <Eigen/Dense>
+
+bool debug = false; // Set to true to enable detailed output
 
 int main() {
     Logger::info("Initializing Neural Network");
 
-    // Define a neural network with 2 layers
+    Eigen::MatrixXd train_data;
+    Eigen::VectorXi train_labels;
+    Eigen::MatrixXd test_data;
+    Eigen::VectorXi test_labels;
+
+    // Load MNIST training and testing datasets
+    DataLoader::load_mnist_csv("../data/mnist_train.csv", train_data, train_labels);
+    DataLoader::load_mnist_csv("../data/mnist_test.csv", test_data, test_labels);
+
+    // Define the neural network structure for MNIST
     NeuralNetwork nn;
-    nn.add_layer(new DenseLayer(2, 5));  // Input layer
-    nn.add_layer(new DenseLayer(5, 1));  // Output layer
+    nn.add_layer(new DenseLayer(784, 128));   // First hidden layer with input size 784
+    nn.add_layer(new DenseLayer(128, 64));    // Second hidden layer
+    nn.add_layer(new DenseLayer(64, 10));     // Output layer with 10 units for 10 classes
 
-    // Compile the model with SGD optimizer and MSE loss
-    nn.compile(new SGD(0.01), new MSE());
+    // Compile the model with an optimizer and loss function suitable for classification
+    nn.compile(new SGD(0.01), new CrossEntropyLoss());
 
-    // Load dataset
-    Eigen::MatrixXd X = DataLoader::load_csv("data/train_X.csv");
-    Eigen::MatrixXd Y = DataLoader::load_csv("data/train_Y.csv");
+    // Train the model on the MNIST training data
+    nn.train(train_data, train_labels, 10, 64);  // 10 epochs, batch size of 64
 
-    // Train the model
-    nn.train(X, Y, 100);
+    // Evaluate model accuracy on the test data
+    double accuracy = nn.evaluate(test_data, test_labels);
+    std::cout << "Test Accuracy: " << accuracy << "%" << std::endl;
 
     return 0;
 }

--- a/src/utils/DataLoader.cpp
+++ b/src/utils/DataLoader.cpp
@@ -2,26 +2,82 @@
 #include <fstream>
 #include <sstream>
 #include <vector>
+#include <iostream>
 
-Eigen::MatrixXd DataLoader::load_csv(const std::string& file_path) {
+void DataLoader::load_mnist_csv(const std::string& file_path, Eigen::MatrixXd& data, Eigen::VectorXi& labels) {
     std::ifstream file(file_path);
+    if (!file.is_open()) {
+        std::cerr << "Error opening file: " << file_path << std::endl;
+        return;
+    }
+
     std::string line;
-    std::vector<std::vector<double>> data;
-    while (std::getline(file, line)) {
+    std::vector<std::vector<double>> data_rows;
+    std::vector<int> label_values;
+
+    // Read the first line to check if it's a header
+    if (std::getline(file, line)) {
+        // Check if the first line contains any non-numeric characters
+        if (line.find_first_not_of("0123456789,") != std::string::npos) {
+            std::cout << "Detected header row, skipping it." << std::endl;
+            // Skip to the next line
+            std::getline(file, line);
+        }
+    }
+
+    // Process the rest of the lines
+    do {
         std::stringstream ss(line);
         std::string value;
         std::vector<double> row;
-        while (std::getline(ss, value, ',')) {
-            row.push_back(std::stod(value));
+
+        // Read the label (first column)
+        if (!std::getline(ss, value, ',')) {
+            std::cerr << "Error: missing label in line: " << line << std::endl;
+            continue;  // Skip to the next line
         }
-        data.push_back(row);
+
+        try {
+            int label = std::stoi(value);
+            label_values.push_back(label);
+        } catch (const std::invalid_argument& e) {
+            std::cerr << "Error: invalid label '" << value << "' in line: " << line << std::endl;
+            continue;  // Skip to the next line
+        }
+
+        // Read the pixel values
+        while (std::getline(ss, value, ',')) {
+            try {
+                row.push_back(std::stod(value) / 255.0);  // Normalize to [0, 1]
+            } catch (const std::invalid_argument& e) {
+                std::cerr << "Error: invalid pixel value '" << value << "' in line: " << line << std::endl;
+                row.clear();  // Clear the row to avoid incomplete entries
+                break;
+            }
+        }
+
+        // Only add rows that have the expected 784 pixel values
+        if (row.size() == 784) {
+            data_rows.push_back(row);
+        } else {
+            std::cerr << "Error: row does not have 784 pixel values in line: " << line << std::endl;
+            label_values.pop_back();  // Remove the label if row is invalid
+        }
+    } while (std::getline(file, line));
+
+    // Convert vectors to Eigen matrices
+    int num_samples = data_rows.size();
+    int num_features = data_rows[0].size();
+
+    data.resize(num_samples, num_features);
+    labels.resize(num_samples);
+
+    for (int i = 0; i < num_samples; ++i) {
+        labels(i) = label_values[i];
+        for (int j = 0; j < num_features; ++j) {
+            data(i, j) = data_rows[i][j];
+        }
     }
 
-    Eigen::MatrixXd matrix(data.size(), data[0].size());
-    for (size_t i = 0; i < data.size(); ++i) {
-        for (size_t j = 0; j < data[0].size(); ++j) {
-            matrix(i, j) = data[i][j];
-        }
-    }
-    return matrix;
+    std::cout << "Loaded " << num_samples << " samples from " << file_path << std::endl;
 }


### PR DESCRIPTION
Implement functional neural network forward and backward pass with Eigen

- Fixed dimension mismatch in DenseLayer::forward by replicating bias matrix to match output dimensions, resolving Eigen's assertion errors.
- Added debug statements wrapped in a 'debug' flag for easier diagnostics.
- Completed data loading, forward, and backward propagation with test accuracy output.
- Code now successfully runs end-to-end on MNIST dataset.