### PR TITLE
feat: add distributed training with MPI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,12 @@ project(NeuroNet)
 # Set C++ Standard
 set(CMAKE_CXX_STANDARD 17)
 
+# Find MPI package
+find_package(MPI REQUIRED)
+
+# Find CPPREST package
+find_package(cpprestsdk REQUIRED)
+
 # Specify the macOS SDK path for CMake
 if(APPLE)
     set(CMAKE_OSX_SYSROOT "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk")
@@ -12,6 +18,7 @@ endif()
 # Include directories
 include_directories(include)
 include_directories(third_party/eigen-3.4.0)
+include_directories(${MPI_INCLUDE_PATH})
 
 # Add core source files
 set(SRC
@@ -27,3 +34,15 @@ set(SRC
 
 # Create executable
 add_executable(NeuroNet ${SRC})
+
+# Link MPI libraries
+target_link_libraries(NeuroNet PRIVATE ${MPI_LIBRARIES})
+
+# Specify the library path for cpprestsdk
+link_directories(/opt/homebrew/Cellar/cpprestsdk/2.10.19/lib)
+
+# Include the header files for cpprestsdk
+include_directories(/opt/homebrew/Cellar/cpprestsdk/2.10.19/include)
+
+# Use cpprestsdk's CMake alias
+target_link_libraries(NeuroNet PRIVATE cpprestsdk::cpprest)

--- a/include/HyperparameterTuner.h
+++ b/include/HyperparameterTuner.h
@@ -1,0 +1,11 @@
+#pragma once
+#include "NeuralNetwork.h"
+#include "Optimizer.h"
+
+class HyperparameterTuner {
+public:
+    void grid_search(const Eigen::MatrixXd& X, const Eigen::MatrixXd& Y, const std::vector<double>& learning_rates, const std::vector<int>& batch_sizes, int epochs);
+
+private:
+    void evaluate_model(double learning_rate, int batch_size, const Eigen::MatrixXd& X, const Eigen::MatrixXd& Y, int epochs);
+};

--- a/include/MSE.h
+++ b/include/MSE.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "Loss.h"
+#include <Eigen/Dense>
+
+class MSE : public Loss {
+public:
+    double calculate(const Eigen::MatrixXd& Y_pred, const Eigen::MatrixXd& Y_true) override {
+        return (Y_pred - Y_true).squaredNorm() / Y_true.rows();
+    }
+
+    Eigen::MatrixXd gradient(const Eigen::MatrixXd& Y_pred, const Eigen::MatrixXd& Y_true) override {
+        return 2.0 * (Y_pred - Y_true) / Y_true.rows();
+    }
+};

--- a/include/ModelServer.h
+++ b/include/ModelServer.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "NeuralNetwork.h"
+#include <string>
+
+class ModelServer {
+public:
+    ModelServer(const std::string& model_path);
+    void start_server(int port);
+    Eigen::MatrixXd predict(const Eigen::MatrixXd& input);
+
+private:
+    NeuralNetwork nn;
+};

--- a/include/NAS.h
+++ b/include/NAS.h
@@ -1,0 +1,10 @@
+#pragma once
+#include "NeuralNetwork.h"
+
+class NAS {
+public:
+    void search(const Eigen::MatrixXd& X, const Eigen::MatrixXd& Y, const std::vector<int>& layer_options, int epochs, int batch_size);
+
+private:
+    void evaluate_architecture(const std::vector<int>& architecture, const Eigen::MatrixXd& X, const Eigen::MatrixXd& Y, int epochs, int batch_size);
+};

--- a/include/NeuralNetwork.h
+++ b/include/NeuralNetwork.h
@@ -2,6 +2,7 @@
 #include <vector>
 #include <memory> 
 #include <Eigen/Dense>
+#include <mpi.h>
 #include "Layer.h"
 #include "Optimizer.h"
 #include "Loss.h"
@@ -10,6 +11,11 @@ class NeuralNetwork {
 public:
     NeuralNetwork();
     ~NeuralNetwork();  // Destructor for cleanup
+
+    std::vector<Layer*> dynamic_layers;
+    
+    void add_dynamic_layer(Layer* layer);
+    Eigen::MatrixXd forward_dynamic(const Eigen::MatrixXd& input);
 
     void add_layer(Layer* layer);
     Eigen::MatrixXd forward(const Eigen::MatrixXd& input);
@@ -28,6 +34,9 @@ public:
 
     // Loss history tracking
     void save_loss_history(const std::string& file_path);
+
+    // Distributed Training
+    void train_distributed(const Eigen::MatrixXd& X, const Eigen::MatrixXd& Y, int epochs, int batch_size, MPI_Comm comm);
 
 private:
     std::vector<std::unique_ptr<Layer>> layers;  // Use smart pointers

--- a/src/core/HyperparameterTuner.cpp
+++ b/src/core/HyperparameterTuner.cpp
@@ -1,0 +1,24 @@
+#include "HyperparameterTuner.h"
+#include "MSE.h"
+#include <iostream>
+
+void HyperparameterTuner::grid_search(const Eigen::MatrixXd& X, const Eigen::MatrixXd& Y, const std::vector<double>& learning_rates, const std::vector<int>& batch_sizes, int epochs) {
+    for (double lr : learning_rates) {
+        for (int batch_size : batch_sizes) {
+            evaluate_model(lr, batch_size, X, Y, epochs);
+        }
+    }
+}
+
+void HyperparameterTuner::evaluate_model(double learning_rate, int batch_size, const Eigen::MatrixXd& X, const Eigen::MatrixXd& Y, int epochs) {
+    NeuralNetwork nn;
+    nn.add_layer(new DenseLayer(X.rows(), 128));  // Example architecture
+    nn.add_layer(new DenseLayer(128, Y.rows()));
+
+    Optimizer* opt = new Adam(learning_rate);
+    nn.compile(opt, new MSE());
+    
+    nn.train(X, Y, epochs, batch_size);
+    
+    std::cout << "Learning rate: " << learning_rate << ", Batch size: " << batch_size << std::endl;
+}

--- a/src/core/MSE.cpp
+++ b/src/core/MSE.cpp
@@ -1,0 +1,1 @@
+#include "MSE.h"

--- a/src/core/ModelServer.cpp
+++ b/src/core/ModelServer.cpp
@@ -1,0 +1,90 @@
+#include "ModelServer.h"
+#include <iostream>
+#include <cpprest/http_listener.h>
+#include <cpprest/json.h>
+
+using namespace web;
+using namespace http;
+using namespace utility;
+using namespace http::experimental::listener;
+
+ModelServer::ModelServer(const std::string& model_path) {
+    nn.load_model(model_path);  // Load the pre-trained model
+}
+
+void ModelServer::start_server(int port) {
+    http_listener listener(U("http://localhost:" + std::to_string(port)));
+
+    listener.support(methods::POST, [this](http_request request) {
+        request.extract_json().then([this, &request](pplx::task<json::value> task) {
+            try {
+                auto input_json = task.get();
+                Eigen::MatrixXd input = json_to_eigen(input_json);
+
+                auto output = predict(input);
+
+                // Convert output to JSON and send response
+                json::value response = eigen_to_json(output);
+                request.reply(status_codes::OK, response);
+            } catch (const std::exception& e) {
+                request.reply(status_codes::BadRequest, "Invalid JSON input");
+            }
+        });
+    });
+
+    listener.open().wait();
+    std::cout << "Model server running on port " << port << std::endl;
+}
+
+Eigen::MatrixXd ModelServer::predict(const Eigen::MatrixXd& input) {
+    return nn.forward(input);
+}
+
+Eigen::MatrixXd json_to_eigen(const json::value& json_obj) {
+    // Ensure the JSON object is an array
+    if (!json_obj.is_array()) {
+        throw std::invalid_argument("Provided JSON object is not an array");
+    }
+
+    // Get the array
+    const auto& arr = json_obj.as_array();
+    int rows = static_cast<int>(arr.size());
+    if (rows == 0) {
+        throw std::invalid_argument("Empty JSON array provided");
+    }
+
+    // Get the number of columns from the first row
+    const auto& first_row = arr.at(0).as_array();
+    int cols = static_cast<int>(first_row.size());
+
+    // Initialize Eigen matrix
+    Eigen::MatrixXd matrix(rows, cols);
+
+    // Populate the Eigen matrix
+    for (int i = 0; i < rows; ++i) {
+        const auto& row = arr.at(i).as_array(); // Access row as JSON array
+        if (static_cast<int>(row.size()) != cols) {
+            throw std::invalid_argument("Inconsistent number of columns in JSON rows");
+        }
+
+        for (int j = 0; j < cols; ++j) {
+            matrix(i, j) = row.at(j).as_double(); // Access element and convert to double
+        }
+    }
+
+    return matrix;
+}
+
+json::value eigen_to_json(const Eigen::MatrixXd& matrix) {
+    json::value result = json::value::array();
+
+    for (int i = 0; i < matrix.rows(); ++i) {
+        json::value row = json::value::array();
+        for (int j = 0; j < matrix.cols(); ++j) {
+            row[j] = json::value::number(matrix(i, j));
+        }
+        result[i] = std::move(row);
+    }
+
+    return result;
+}

--- a/src/core/NAS.cpp
+++ b/src/core/NAS.cpp
@@ -1,0 +1,35 @@
+#include "NAS.h"
+#include "MSE.h"
+#include <iostream>
+
+void NAS::search(const Eigen::MatrixXd& X, const Eigen::MatrixXd& Y, const std::vector<int>& layer_options, int epochs, int batch_size) {
+    // Iterate over possible architectures
+    for (int hidden_layers : layer_options) {
+        for (int nodes_per_layer : layer_options) {
+            std::vector<int> architecture = {hidden_layers, nodes_per_layer};
+            evaluate_architecture(architecture, X, Y, epochs, batch_size);
+        }
+    }
+}
+
+void NAS::evaluate_architecture(const std::vector<int>& architecture, const Eigen::MatrixXd& X, const Eigen::MatrixXd& Y, int epochs, int batch_size) {
+    NeuralNetwork nn;
+    
+    // Build the architecture
+    nn.add_layer(new DenseLayer(X.rows(), architecture[0]));  // First hidden layer
+    for (int i = 1; i < architecture.size(); ++i) {
+        nn.add_layer(new DenseLayer(architecture[i-1], architecture[i]));  // Hidden layers
+    }
+    nn.add_layer(new DenseLayer(architecture.back(), Y.rows()));  // Output layer
+
+    nn.compile(new Adam(0.001), new MSE());
+    
+    // Train and evaluate the model
+    nn.train(X, Y, epochs, batch_size);
+    
+    std::cout << "Tested architecture: ";
+    for (int layer_size : architecture) {
+        std::cout << layer_size << " ";
+    }
+    std::cout << std::endl;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,8 +79,13 @@ int main(int argc, char* argv[]) {
     }
 
     // Save the training loss history to a file
-    Logger::info("Saving the training loss history...");
-    nn.save_loss_history(models_dir + "../training_loss.csv");
+    // Logger::info("Saving the training loss history...");
+    // nn.save_loss_history(models_dir + "../training_loss.csv");
+    // std::string loss_history_path = std::filesystem::path(models_dir) / "training_loss.csv";
+    std::string loss_history_path = std::filesystem::absolute(std::filesystem::path(models_dir) / "training_loss.csv").string();
+    std::cout << "Full path for loss history: " << loss_history_path << std::endl;
+    Logger::info("Saving loss history to: " + loss_history_path);
+    nn.save_loss_history(loss_history_path);
 
     // Evaluate model accuracy on the test data
     double accuracy = nn.evaluate(test_data, test_labels);


### PR DESCRIPTION
### Changes Made
- Integrated MPI for distributed training.
- Added NAS and HyperparameterTuner classes.
- Implemented ModelServer for deployment.
- Modified NeuralNetwork to support dynamic layers.
- Updated the build system to link MPI and cpprestsdk.
- Added detailed logging for debugging and error handling.

### How to Test
1. Distributed Training:
	- Run mpirun -n <number_of_nodes> ./NeuroNetCPP to test distributed training.
2. NAS and Hyperparameter Tuning:
	- Invoke NAS::search and HyperparameterTuner::grid_search with sample datasets to verify functionality.
3. Model Deployment:
	- Start the server using ./NeuroNetCPP --serve --model models/neuro_net.model --port 8080.
	- Send a POST request with sample input to test inference.
4. Dynamic Graph:
	- Add layers dynamically using NeuralNetwork::add_dynamic_layer and verify the forward pass.
5. Loss History File:
	- Train a model and ensure training_loss.csv is saved correctly in the models directory.
	